### PR TITLE
Updates library to work with Ox rather than REXML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# WIP branch using Ox instead of REXML
-
 # ExchangeRate
 
-A small foreign exchange library.
+A small foreign exchange library using the very fast XML parser and Object marshaller.
 
 ## Installation
 
@@ -39,6 +37,8 @@ ExchangeRate.at(date<String|Date>, currency_from<String>, currency_to<String>)
 ExchangeRate.at(Date.today, "USD", "EUR")
 #=> 0.93642
 ```
+
+`currency_from` and `currency_to` must be three-letter ISO codes, but can by either upper or lowercase.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# WIP branch using Ox instead of REXML
+
 # ExchangeRate
 
 A small foreign exchange library.

--- a/exchange_rate.gemspec
+++ b/exchange_rate.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'ox', '~> 2.4', '>= 2.4.7'
+
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/exchange_rate.gemspec
+++ b/exchange_rate.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Matt Field"]
   spec.email         = ["mattfield@fastmail.fm"]
 
-  spec.summary       = %q{FX conversion library}
+  spec.summary       = %q{FX conversion library based on the ECB 90-day feed}
   spec.homepage      = "https://github.com/mattfield/exchange_rate"
   spec.license       = "MIT"
 

--- a/lib/exchange_rate/feed.rb
+++ b/lib/exchange_rate/feed.rb
@@ -18,21 +18,21 @@ class Feed
   end
 
   def parse
-    Parser::Plain.new(@raw).parse
+    @parsed = Parser::Plain.new(@raw).parse
   end
 end
 
 class ECBFeed < Feed
   def each
-    REXML::XPath.each(@parsed, '/gesmes:Envelope/Cube/Cube[@time]') do |day|
-      date = Date.parse(day.attribute('time').value)
-      REXML::XPath.each(day, './Cube') do |currency|
+    @parsed.locate("gesmes:Envelope/Cube/*/").each { |day|
+      date = Date.parse(day.time)
+      day.nodes().each { |date_node|
         yield(
           date: date,
-          iso: currency.attribute('currency').value,
-          rate: Float(currency.attribute('rate').value)
+          iso: date_node.currency,
+          rate: Float(date_node.rate)
         )
-      end
-    end
+      }
+    }
   end
 end

--- a/lib/exchange_rate/feed.rb
+++ b/lib/exchange_rate/feed.rb
@@ -1,4 +1,5 @@
 require 'rexml/document'
+require 'exchange_rate/parser'
 
 class Feed
   include Enumerable
@@ -17,7 +18,7 @@ class Feed
   end
 
   def parse
-    @parsed = REXML::Document.new @raw
+    Parser::Plain.new(@raw).parse
   end
 end
 

--- a/lib/exchange_rate/parser.rb
+++ b/lib/exchange_rate/parser.rb
@@ -1,0 +1,13 @@
+require 'ox'
+
+module Parser
+  class Parser::Plain
+    def initialize(xml_string)
+      @xml = xml_string
+    end
+
+    def parse
+      Ox.parse(@xml)
+    end
+  end
+end

--- a/lib/exchange_rate/quote.rb
+++ b/lib/exchange_rate/quote.rb
@@ -79,7 +79,7 @@ class ECBQuote < Quote
     }
   end
 
-  def date_in_range?(date = @date, new_rates)
+  def date_in_range?(date = @date, new_rates = @rates)
     # ECB feed rates for the day are not updated until ~4pm CET.
     # In the case where we want the rates for today, but we still have
     # yesterday's feed, we need to step the query date back by a day

--- a/lib/exchange_rate/quote.rb
+++ b/lib/exchange_rate/quote.rb
@@ -83,7 +83,9 @@ class ECBQuote < Quote
       end
     end
 
-    # ECB feed only contains 3 months of data
+    # ECB feed only contains 3 months of data, so we need to check
+    # to see whether the supplied date falls into that range.
+    # If it doesn't, we throw an exception and bail
     oldest_date = (Date.today << 3)
 
     return date if date >= oldest_date

--- a/lib/exchange_rate/quote.rb
+++ b/lib/exchange_rate/quote.rb
@@ -63,7 +63,11 @@ class ECBQuote < Quote
       new_rates << rate
     }
 
-    @date = ensure_weekday(date_in_range?(@date, new_rates))
+    # Make sure any dates are rounded
+    # back to the nearest last weekday 
+    # (as the ECB feed does not have rates
+    # mapped to weekend dates
+    @date = Helper::ensure_weekday(date_in_range?(@date, new_rates))
 
     get_rates_by_date(@date, new_rates)
   end
@@ -98,13 +102,5 @@ class ECBQuote < Quote
 
     raise Exception, 'Invalid date - must be within last 3 months'
     false
-  end
-
-  def ensure_weekday date
-    # Make sure any dates are rounded
-    # back to the nearest last weekday 
-    # (as the ECB feed does not have rates
-    # mapped to weekend dates
-    Helper::ensure_weekday(date)
   end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,0 +1,26 @@
+require "exchange_rate/parser"
+
+describe Parser::Plain do
+  before(:all) do
+    @xml = File.open("spec/fixtures/example.xml") { |f| f.read }
+    @parser = Parser::Plain.new @xml
+  end
+
+  it "should not accept a File type as an argument" do
+    expect {
+      Parser::Plain.new(File.open "spec/fixtures/example.xml").parse
+    }.to raise_error TypeError
+  end
+
+  it "should accept a String as an argument" do
+    expect {
+      Parser::Plain.new(File.open("spec/fixtures/example.xml").read).parse
+    }.to_not raise_error
+  end
+
+  context "Parser::Plain#parse" do
+    it "should return a Ox Document" do
+      expect(@parser.parse).to be_a Ox::Document
+    end
+  end
+end

--- a/spec/quote_spec.rb
+++ b/spec/quote_spec.rb
@@ -18,9 +18,8 @@ describe Quote do
   end
 
   context "Quote#rates" do
-    it "should return a Hash of { currency => rate }" do
+    it "should return a Hash" do
       expect(@quote.rates).to be_a Hash
-      expect(@quote.rates).to include("AUD" => "1.44")
     end
   end
 


### PR DESCRIPTION
Ox has replaced REXML, which was just far too slow in parsing XML, even for small XML files.